### PR TITLE
Add Mariana as an author, so she can have rights on the cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vader_sentiment"
 version = "0.1.0"
-authors = ["Chris <chriswong21@berkeley.edu>"]
+authors = ["Chris <chriswong21@berkeley.edu>", "Mariana Meireles <mariana@psychonautgirl.space>"]
 license = "MIT"
 description = "Bindings for Rust from the original Python VaderSentiment analysis tool."
 repository = "https://github.com/ckw017/vader-sentiment-rust"


### PR DESCRIPTION
Hey @ckw017 the command `cargo owner --add github-handle` wasn't working for me, so I thought it was better to add me here as an author so I have right over the package on cargo!