### PR TITLE
Add: separated module readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ VADER (Valence Aware Dictionary and sEntiment Reasoner) is a lexicon and rule-ba
       println!("{:#?}", analyzer.polarity_scores("VADER is VERY SMART, handsome, and FUNNY."));
   }
 ```
+#### Separated Module
+
+```rust
+use std::collections::HashMap;
+use vader_sentiment;
+pub async fn get_sentiment(text: &str) -> HashMap<String, f64> {
+    let analyzer = vader_sentiment::SentimentIntensityAnalyzer::new();
+    let hmap = analyzer.polarity_scores(text);
+    hmap.into_iter()
+        .map(|(s, n)| (s.to_string(), n))
+        .collect::<HashMap<String, f64>>()
+}
+```
 
 ### Output
 ``` rust


### PR DESCRIPTION
Hi, I have tried to extract the sentiment analyzer into a separate function but the example from the docs didn't work, I have figured out how to deal with it and wanted to contribute to this project, maybe someone will encounter the same problem in the future.